### PR TITLE
Use right yarn path on apply

### DIFF
--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -81,7 +81,7 @@ func (l *Launcher) Apply() error {
 			}
 		}
 	}
-	if _, err := os.Stat("deps/yarn/bin/yarn"); os.IsNotExist(err) {
+	if _, err := os.Stat(install.YarnPath); os.IsNotExist(err) {
 		log.Print("Installing Yarn")
 		err = install.Yarn()
 		if err != nil {


### PR DESCRIPTION
Currently the apply function got the path to yarn hard-coded even if
there are paths defined within the install package. I know that the
paths differe a little bit as the hard-coded path doesn't include the
.js suffix, but this difference doesn't break any functionality. With
this change somebody who is compiling the tool on his own is able to
manipulate the required paths.

Signed-off-by: Thomas Boerger <thomas@webhippie.de>