### PR TITLE
fix(yarn): Loop through all yarn releases

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -114,8 +114,9 @@ func Yarn() error {
 	type releases struct {
 		Assets []asset
 	}
+	
 
-	url := "https://api.github.com/repos/yarnpkg/yarn/releases/latest"
+	url := "https://api.github.com/repos/yarnpkg/yarn/releases"
 
 	yarnClient := http.Client{
 		Timeout: time.Second * 2, // Maximum of 2 secs
@@ -138,7 +139,7 @@ func Yarn() error {
 		return readErr
 	}
 
-	rel := releases{}
+	rel := []releases{}
 	err = json.Unmarshal(body, &rel)
 	if err != nil {
 		fmt.Println(err)
@@ -146,13 +147,17 @@ func Yarn() error {
 	}
 
 	var file string
-	for _, asset := range rel.Assets {
-		if strings.HasSuffix(asset.Name, ".tar.gz") {
-			file = asset.Name
-			download(file, asset.URL)
-			break
+	Loop:
+		for _, release := range rel {
+			for _, asset := range release.Assets {
+				if strings.HasSuffix(asset.Name, ".tar.gz") {
+					file = asset.Name
+					log.Print(file)
+					download(file, asset.URL)
+					break Loop
+				}
+			}
 		}
-	}
 
 	err = extractTarGz("deps", file)
 	if err != nil {

--- a/install/install.go
+++ b/install/install.go
@@ -114,7 +114,6 @@ func Yarn() error {
 	type releases struct {
 		Assets []asset
 	}
-	
 
 	url := "https://api.github.com/repos/yarnpkg/yarn/releases"
 
@@ -147,17 +146,17 @@ func Yarn() error {
 	}
 
 	var file string
-	Loop:
-		for _, release := range rel {
-			for _, asset := range release.Assets {
-				if strings.HasSuffix(asset.Name, ".tar.gz") {
-					file = asset.Name
-					log.Print(file)
-					download(file, asset.URL)
-					break Loop
-				}
+Loop:
+	for _, release := range rel {
+		for _, asset := range release.Assets {
+			if strings.HasSuffix(asset.Name, ".tar.gz") {
+				file = asset.Name
+				log.Print(file)
+				download(file, asset.URL)
+				break Loop
 			}
 		}
+	}
 
 	err = extractTarGz("deps", file)
 	if err != nil {


### PR DESCRIPTION
As seen in https://github.com/screepers/screeps-launcher/issues/11
We need to take the latest yarn versions that have a `.tar.gz` file.