### PR TITLE
Fix Issue with Sample Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,8 @@ A few mods of interests:
 - `screepsmod-market`
 
 See each of their documentation on the [ScreepsMods github repository](https://github.com/ScreepsMods).
+
+
+## Bots
+You can add bots to spawn in by adding either their names or path to the code on your file system in the `config.yml` file.  See config.sample.yml for an example.
+

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -9,7 +9,7 @@ mods:
 - screepsmod-auth
 bots:
   simplebot: "screepsbot-zeswarm"
-  overmind: "./bots/overmind/dist/main.js"
+  overmind: "./bots/overmind/dist" # On windows path needs to be .\\bots\\overmind\\dist
 extraPackages:
   morgan: "*"
 localMods: ./mods


### PR DESCRIPTION
Added some information on adding in a bot to spawn to the readme and fixed an issue with the sample config. bots.spawn expects a directory for code not a file to run.