### PR TITLE
Add ability to set pinned package versions in config

### DIFF
--- a/launcher/config.go
+++ b/launcher/config.go
@@ -38,20 +38,21 @@ type ConfigCli struct {
 
 // Config server config structure
 type Config struct {
-	SteamKey      string            `yaml:"steamKey" json:"steamKey"`
-	SteamKeyFile  string            `yaml:"steamKeyFile" json:"steamKeyFile"`
-	Cli           *ConfigCli        `yaml:"cli" json:"cli"`
-	Env           *ConfigEnv        `yaml:"env" json:"env"`
-	Processors    int               `yaml:"processors" json:"processors"`
-	RunnerThreads int               `yaml:"runnerThreads" json:"runnerThreads"`
-	Version       string            `yaml:"version" json:"version"`
-	NodeVersion   string            `yaml:"nodeVersion" json:"nodeVersion"`
-	Mods          []string          `yaml:"mods" json:"mods"`
-	Bots          map[string]string `yaml:"bots" json:"bots"`
-	ExtraPackages map[string]string `yaml:"extraPackages" json:"extraPackages"`
-	LocalMods     string            `yaml:"localMods" json:"localMods"`
-	Backup        *ConfigBackup     `yaml:"backup" json:"backup"`
-	Modules       map[string]bool   `yaml:"modules" json:"modules"`
+	SteamKey       string            `yaml:"steamKey" json:"steamKey"`
+	SteamKeyFile   string            `yaml:"steamKeyFile" json:"steamKeyFile"`
+	Cli            *ConfigCli        `yaml:"cli" json:"cli"`
+	Env            *ConfigEnv        `yaml:"env" json:"env"`
+	Processors     int               `yaml:"processors" json:"processors"`
+	RunnerThreads  int               `yaml:"runnerThreads" json:"runnerThreads"`
+	Version        string            `yaml:"version" json:"version"`
+	NodeVersion    string            `yaml:"nodeVersion" json:"nodeVersion"`
+	Mods           []string          `yaml:"mods" json:"mods"`
+	Bots           map[string]string `yaml:"bots" json:"bots"`
+	ExtraPackages  map[string]string `yaml:"extraPackages" json:"extraPackages"`
+	PinnedPackages map[string]string `yaml:"pinnedPackages" json:"pinnedPackages"`
+	LocalMods      string            `yaml:"localMods" json:"localMods"`
+	Backup         *ConfigBackup     `yaml:"backup" json:"backup"`
+	Modules        map[string]bool   `yaml:"modules" json:"modules"`
 }
 
 // NewConfig Create a new Config
@@ -89,10 +90,11 @@ func NewConfig() *Config {
 				"DB_PATH": "db.json",
 			},
 		},
-		LocalMods:     "mods",
-		Mods:          make([]string, 0),
-		Bots:          make(map[string]string),
-		ExtraPackages: make(map[string]string),
+		LocalMods:      "mods",
+		Mods:           make([]string, 0),
+		Bots:           make(map[string]string),
+		ExtraPackages:  make(map[string]string),
+		PinnedPackages: make(map[string]string),
 		Backup: &ConfigBackup{
 			Dirs:  make([]string, 0),
 			Files: make([]string, 0),

--- a/launcher/packages.go
+++ b/launcher/packages.go
@@ -13,6 +13,7 @@ type PackageJSON struct {
 	Name         string            `json:"name"`
 	Main         string            `json:"main"`
 	Dependencies map[string]string `json:"dependencies"`
+	Resolutions  map[string]string `json:"resolutions"`
 	Private      bool              `json:"private"`
 }
 
@@ -40,6 +41,7 @@ func writePackage(c *Config) error {
 	}
 	var pack PackageJSON
 	pack.Dependencies = deps
+	pack.Resolutions = c.PinnedPackages
 	pack.Private = true
 	pack.Name = "screeps-private-server"
 	bytes, err := json.MarshalIndent(pack, "", "  ")


### PR DESCRIPTION
Add a `pinnedPackages` config option that's passed through to the `resolutions` field in `package.json`.

Some of the upstream packages that are in screeps' dependency chain are starting to release new major versions which drop support for node 12 - without setting some pins, isolated-vm can't build during the yarn build step given the current latest versions of its dependencies on npm.

With this branch's feature plus the following pin configuration, I've gotten the dockerized launcher to successfully complete its yarn build:

```
pinnedPackages:
  ssri: 8.0.1
  cacache: 16.1.3
```