### PR TITLE
Update config.go to include default pinnedPackages

### DIFF
--- a/launcher/config.go
+++ b/launcher/config.go
@@ -94,7 +94,12 @@ func NewConfig() *Config {
 		Mods:           make([]string, 0),
 		Bots:           make(map[string]string),
 		ExtraPackages:  make(map[string]string),
-		PinnedPackages: make(map[string]string),
+		PinnedPackages: map[string]string{
+				"ssri": "8.0.1",
+				"cacache": "16.1.3",
+				"passport-steam": "1.0.17",
+				"minipass-fetch": "3.0.3",
+		},
 		Backup: &ConfigBackup{
 			Dirs:  make([]string, 0),
 			Files: make([]string, 0),


### PR DESCRIPTION
pinnedPackages now defaults to the 4 necessary to make launcher work, per #34.  Pushing this and triggering a new build of screeps-launcher also seems to address the failures to download yarn from github and address https://github.com/screepers/screeps-launcher/issues/37 too.

pinnedPackages:
  ssri: 8.0.1
  cacache: 16.1.3
  passport-steam: 1.0.17
  minipass-fetch: 3.0.3
