### PR TITLE
Install exact yarn version due to upstream change

### DIFF
--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -107,7 +107,7 @@ func (l *Launcher) Apply() error {
 		if err != nil {
 			return err
 		}
-		err = runYarn("set", "version", "berry")
+		err = runYarn("set", "version", "1.22.21")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
A change from https://github.com/yarnpkg/yarn/pull/9009 released in yarn 1.22.20 makes the `yarn set version berry` command no longer valid. Fixes #43 - switched out now-invalid invocation for an exact semver (`yarn set version 1.22.21`) as a workaround.