### PR TITLE
specify mongo:5 image to avoid pulling incompatible mongo version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     restart: unless-stopped
 
   mongo:
-    image: mongo
+    image: mongo:5
     volumes:
       - mongo-data:/data/db
     restart: unless-stopped


### PR DESCRIPTION
Running screeps-launcher via docker compose up will otherwise not work with error about incompatible mongodb version.