### PR TITLE
Suport for mulitple architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang AS builder
 
 ARG ARCH=amd64
+# Use arm64/32 for other architectures.
 
 WORKDIR /app
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM golang AS builder
+
+ARG ARCH=amd64
+
 WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=0 \
     GOOS=linux \
-    GOARCH=amd64 \
+    GOARCH=${ARCH} \
     go build -o screeps-launcher ./cmd/screeps-launcher
 
 FROM buildpack-deps:buster

--- a/README.md
+++ b/README.md
@@ -101,3 +101,6 @@ See each of their documentation on the [ScreepsMods github repository](https://g
 ## Bots
 You can add bots to spawn in by adding either their names or path to the code on your file system in the `config.yml` file.  See config.sample.yml for an example.
 
+## Building for a PI
+
+You can easily build your own docker image for an ARM architecute via the Docker build arg `ARCH`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 version: '3'
 services:
   screeps:
+    build: 
+      context: .
+      args:
+        ARCH: amd64
     image: screepers/screeps-launcher
     volumes:
       - ./config.yml:/screeps/config.yml


### PR DESCRIPTION
This launcher is currently running on a pi.
The proposed changes give some hints to allow somebody else to do so easily.
The build itself should be keept unchanged.