### PR TITLE
Allow host for Docker Compose deployments to be configured via .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 config.yml
 !.circleci/config.yml
 test*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   screeps:
-    build: 
+    build:
       context: .
       args:
         ARCH: amd64
@@ -10,7 +10,7 @@ services:
       - ./config.yml:/screeps/config.yml
       - screeps-data:/screeps
     ports:
-      - 21025:21025/tcp
+      - "${SCREEPS_LAUNCHER_HOST:-0.0.0.0}:21025:21025/tcp"
     environment:
       MONGO_HOST: mongo
       REDIS_HOST: redis


### PR DESCRIPTION
Updates the port binding in `docker-compose.yml` to use `$SCREEPS_LAUNCHER_HOST` (which defaults to `0.0.0.0` and can be set in a `.env` file) to set the host used for the server port binding in the Docker Compose deployment.

The intent is to allow a containerized deployment of screeps-launcher to be restricted to specific hosts to facilitate use cases like an ad-hoc test server that is only accessible via localhost.