### PR TITLE
Add cache mount for Docker go build step

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ on:
       - main
     tags:
       - 'v*'
-    
+
   workflow_dispatch:
 
 jobs:
@@ -32,6 +32,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up Docker Buildx
+        id: docker_buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
         uses: docker/login-action@7ca345011ac4304463197fac0e56eab1bc7e6af0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ARG ARCH=amd64
 
 WORKDIR /app
 COPY . .
-RUN CGO_ENABLED=0 \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 \
     GOOS=linux \
     GOARCH=${ARCH} \
     go build -o screeps-launcher ./cmd/screeps-launcher


### PR DESCRIPTION
Implements the cache mount change from reverted PR #52 , and initializes Docker BuildKit in CI to utilize the cache mount there.