### PR TITLE
Add UID/GID build args to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,20 @@ RUN CGO_ENABLED=0 \
     go build -o screeps-launcher ./cmd/screeps-launcher
 
 FROM buildpack-deps:buster
-RUN groupadd --gid 1000 screeps \
-  && useradd --uid 1000 --gid screeps --shell /bin/bash --create-home screeps \
-  && mkdir /screeps && chown screeps.screeps /screeps
-USER screeps
+
+ARG UID=1000
+ARG GID=1000
+RUN <<-EOT bash
+    if [[ "${GID}" != "0" ]] ; then
+        groupadd --gid ${GID} screeps
+    fi
+    if [[ "${UID}" != "0" ]] ; then
+        useradd --uid ${UID} --gid ${GID} --shell /bin/bash --create-home screeps
+    fi
+    mkdir /screeps && chown ${UID}:${GID} /screeps
+EOT
+
+USER ${UID}:${GID}
 VOLUME /screeps
 WORKDIR /screeps
 COPY --from=builder /app/screeps-launcher /usr/bin/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       context: .
       args:
         ARCH: amd64
+        UID: 1000
+        GID: 1000
     image: screepers/screeps-launcher
     volumes:
       - ./config.yml:/screeps/config.yml


### PR DESCRIPTION
Allows UID/GID of the docker container user to be configured, which can help with file permissions in volumes on containerized deployments (ex: when using rootless daemons). The previous value of 1000 for both the UID and GID is used by default.

Tested by running `docker compose build` with UID/GID set to 1000/1000 as well as 0/0.