### PR TITLE
Update Docker launcher for Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     GOARCH=${ARCH} \
     go build -o screeps-launcher ./cmd/screeps-launcher
 
-FROM buildpack-deps:buster
+FROM buildpack-deps:bookworm
+
+ENV PYTHON=/usr/bin/python3 \
+    npm_config_python=/usr/bin/python3
 
 ARG UID=1000
 ARG GID=1000

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -8,9 +8,10 @@ pinnedPackages:
   express-rate-limit: 6.7.0
 env:
   shared:
-    MONGO_HOST: localhost
-    REDIS_HOST: localhost
+    MONGO_HOST: mongo
+    REDIS_HOST: redis
 version: latest
+nodeVersion: v22.9.0
 mods:
 - screepsmod-mongo
 - screepsmod-auth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   screeps:
     build:
@@ -7,7 +6,7 @@ services:
         ARCH: amd64
         UID: 1000
         GID: 1000
-    image: screepers/screeps-launcher
+    # image: screepers/screeps-launcher
     volumes:
       - ./config.yml:/screeps/config.yml
       - screeps-data:/screeps
@@ -23,7 +22,13 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "sh", "-c", "curl --fail --silent http://127.0.0.1:21025/"]
+      test:
+        [
+          "CMD-SHELL",
+          "sh",
+          "-c",
+          "curl --fail --silent http://127.0.0.1:21025/",
+        ]
       interval: 30s
       timeout: 5s
       start_period: 5s
@@ -36,7 +41,13 @@ services:
       - mongo-data:/data/db
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "sh", "-c", "echo 'db.runCommand(\"ping\").ok' | mongosh localhost:27017/test --quiet"]
+      test:
+        [
+          "CMD-SHELL",
+          "sh",
+          "-c",
+          'echo ''db.runCommand("ping").ok'' | mongosh localhost:27017/test --quiet',
+        ]
       interval: 30s
       timeout: 5s
       start_period: 5s

--- a/install/install.go
+++ b/install/install.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -28,6 +29,8 @@ type NodeVersion struct {
 	Modules string
 	Lts     interface{}
 }
+
+var exactNodeVersionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
 
 func download(dest string, url string) error {
 	client := grab.NewClient()
@@ -235,14 +238,24 @@ func GetNodeVersion(version string) (string, error) {
 		return "", err
 	}
 
-	ver := version
-	if version[0:1] != "v" {
-		ver = getWantedVersion(version, versions)
-	}
+	ver := resolveRequestedNodeVersion(version, versions)
 	if ver == "" {
 		return "", fmt.Errorf("Could not find node version: %s", version)
 	}
 	return ver, nil
+}
+
+func resolveRequestedNodeVersion(version string, versions []NodeVersion) string {
+	if version == "" {
+		return ""
+	}
+	if exactNodeVersionPattern.MatchString(version) {
+		return "v" + version
+	}
+	if strings.HasPrefix(version, "v") {
+		return version
+	}
+	return getWantedVersion(version, versions)
 }
 
 func getWantedVersion(version string, versions []NodeVersion) string {

--- a/install/install_test.go
+++ b/install/install_test.go
@@ -45,3 +45,25 @@ func TestGetWantedVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveRequestedNodeVersion(t *testing.T) {
+	versions := []NodeVersion{
+		NodeVersion{Lts: "Erbium", Version: "v12.22.12"},
+		NodeVersion{Lts: "Jod", Version: "v22.9.0"},
+	}
+	tables := []struct {
+		ver string
+		ret string
+	}{
+		{"22.9.0", "v22.9.0"},
+		{"v22.9.0", "v22.9.0"},
+		{"Jod", "v22.9.0"},
+		{"", ""},
+	}
+	for _, table := range tables {
+		ret := resolveRequestedNodeVersion(table.ver, versions)
+		if ret != table.ret {
+			t.Errorf("resolveRequestedNodeVersion(%s, %v) was incorrect, got: %s, want: %s", table.ver, versions, ret, table.ret)
+		}
+	}
+}

--- a/launcher/config.go
+++ b/launcher/config.go
@@ -63,7 +63,7 @@ func NewConfig() *Config {
 		Processors:    cores,
 		RunnerThreads: int(runners),
 		Version:       "latest",
-		NodeVersion:   "Erbium",
+		NodeVersion:   "v22.9.0",
 		Cli: &ConfigCli{
 			Username: "",
 			Password: "",

--- a/launcher/server.go
+++ b/launcher/server.go
@@ -3,6 +3,7 @@ package launcher
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -124,9 +125,11 @@ func (s *Server) runModule(ctx context.Context, name string, module string, env 
 		}
 		lenv = append(lenv, fmt.Sprintf("PATH=%s", strings.Join(newPath, string(filepath.ListSeparator))))
 		fmt.Fprintf(f, "==== %s Starting ====\n", name)
+		stdout := io.MultiWriter(os.Stdout, f)
+		stderr := io.MultiWriter(os.Stderr, f)
 		cmd := exec.CommandContext(ctx, filepath.Join("node_modules", ".bin", module))
-		cmd.Stdout = f
-		cmd.Stderr = f
+		cmd.Stdout = stdout
+		cmd.Stderr = stderr
 		cmd.Env = lenv
 		err := cmd.Run()
 		log.Printf("[%s] Exited with error: %v", name, err)


### PR DESCRIPTION
WARNING: i used ai for this. if ai is not allowed then say so. 

this PR would fix #199 
note i did not do any extensive testing. but i can connect and spawn in the server. 

This change updates the launcher’s default Node runtime from the old `Erbium` default to `v22.9.0`, which is required by current `screeps@4.3.0`. It also normalizes exact version input so both `22.9.0` and `v22.9.0` resolve correctly, while preserving support for LTS codenames.

The Docker runtime image is moved from Debian Buster to Bookworm and now explicitly points `node-gyp` at `/usr/bin/python3`. This fixes native module builds under Node 22, where the previous image still exposed Python 3.7 and failed during `isolated-vm` compilation.

For Docker-based setups, the checked-in and sample configs now use Compose service names for Redis and Mongo:
- `MONGO_HOST: mongo`
- `REDIS_HOST: redis`

This avoids the previous misconfiguration where `localhost` inside the `screeps` container caused runtime `ECONNREFUSED` errors against Redis. The obsolete top-level Compose `version` key was also removed.

The launcher now mirrors child module stdout/stderr to container stdout/stderr in addition to log files. Previously, backend/main/processor failures often surfaced only as `Exited with error: exit status 1`, which made diagnosis unnecessarily difficult in `docker compose logs`.

Files changed:
- `Dockerfile`
- `config.sample.yml`
- `docker-compose.yml`
- `install/install.go`
- `install/install_test.go`
- `launcher/config.go`
- `launcher/server.go