### PR TITLE
docs: update README and config for Node 24 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ that does a step-by-step setup including mongo, redis, and auto start.
 
 You can use `screeps-launcher cli` in the same folder for CLI access
 
+### Node.js Version
+The launcher automatically manages its own Node.js installation. By default, it uses **Node 24 (Krypton)**. If you need a different version, you can specify it in your `config.yml`:
+
+```yaml
+nodeVersion: Krypton # or "20", "Iron", "v22.11.0", etc.
+```
+
 ### Other options
 
 There are several extra arguments that can be used to manage the install:

--- a/launcher/config.go
+++ b/launcher/config.go
@@ -63,7 +63,7 @@ func NewConfig() *Config {
 		Processors:    cores,
 		RunnerThreads: int(runners),
 		Version:       "latest",
-		NodeVersion:   "Erbium",
+		NodeVersion:   "Krypton",
 		Cli: &ConfigCli{
 			Username: "",
 			Password: "",


### PR DESCRIPTION
Updates to have Node 24 as the default version