### PR TITLE
ci: remove redundant and misconfigured upload-release-asset step

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -70,12 +70,3 @@ jobs:
           files: |
             screeps-launcher*
             config.sample.yml
-      - name: Upload binaries
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./bin
-          asset_name: screeps-launcher_${{ matrix.os }}_${{ matrix.arch }}
-          asset_content_type: application/octet-stream


### PR DESCRIPTION
Hello! 

This PR fixes the release pipeline failure (`Input required and not supplied: upload_url`) by removing a redundant `upload-release-asset` step.

The previous `softprops/action-gh-release` step is already configured to upload all binaries (screeps-launcher*) and the sample config. The subsequent step was misconfigured and unnecessary, so I have consolidated the process into the main release action.

Changes:

Removed redundant actions/upload-release-asset@v1 from .github/workflows/go.yaml.

- Relied on the existing gh-release step for asset uploads.
- Thank you for your time and for maintaining this project!

