### PR TITLE
chore: sync go version to 1.26 across all components

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -3,7 +3,7 @@ name: Build and Release
 on: [push]
 
 env:
-  go-version: 1.22.x
+  go-version: 1.26.x
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-trixie AS builder
 
 # TARGETARCH and TARGETVARIANT are provided by buildx
 ARG TARGETOS
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     GOARM=${TARGETVARIANT#v} \
     go build -o screeps-launcher ./cmd/screeps-launcher
 
-FROM buildpack-deps:buster
+FROM buildpack-deps:trixie
 
 ARG UID=1000
 ARG GID=1000

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,8 @@
             src = ./.;
             modules = ./gomod2nix.toml;
             subPackages = [ "cmd/screeps-launcher" ];
-            # force 1.22, 1.23 is currently broken due to modules.txt not being generated
-            go = pkgs.go_1_22; 
+            # try 1.26, 1.23 was previously broken due to modules.txt not being generated
+            go = pkgs.go_1_26; 
           };
         in
         {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/screepers/screeps-launcher/v1
 
-go 1.23.0
+go 1.26.0
 
 require (
 	github.com/c-bata/go-prompt v0.2.6


### PR DESCRIPTION
Update to use go version 1.26 across all components