### PR TITLE
feat(flake): dynamic version from git and latest go

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,9 @@
       "before 4am"
     ]
   },
+  "githubActions": {
+    "pinDigests": true
+  },
   "packageRules": [
     {
       "matchUpdateTypes": [
@@ -21,6 +24,13 @@
       ],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },
+    {
+      "description": "Auto-merge GitHub Actions digest updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": true,
+      "automergeType": "pr"
     }
   ]
 }

--- a/.github/workflows/gomod2nix.yaml
+++ b/.github/workflows/gomod2nix.yaml
@@ -1,0 +1,43 @@
+name: Update gomod2nix
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: write
+  pull-requests: write
+  merge-groups: write
+
+jobs:
+  update-gomod2nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate gomod2nix
+        run: nix develop -c gomod2nix generate
+
+      - name: Create PR with changes
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore: update gomod2nix'
+          title: 'chore: update gomod2nix'
+          body: |
+            Auto-generated PR to update gomod2nix after go.mod changes.
+          branch: gomod2nix-update
+          delete-branch: true
+
+      - name: Enable Auto-merge
+        if: steps.cpr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1753096219,
-        "narHash": "sha256-MaaWYgN/nia7xJcOYLBtPk+cFo7X2zEM1d9xIGPQrLU=",
+        "lastModified": 1770585520,
+        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
         "owner": "nix-community",
         "repo": "gomod2nix",
-        "rev": "be828766411cad04c194c8f714d46aa2b2596362",
+        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658285632,
-        "narHash": "sha256-zRS5S/hoeDGUbO+L95wXG9vJNwsSYcl93XiD0HQBXLk=",
+        "lastModified": 1755864489,
+        "narHash": "sha256-ojoEEg2c8gTyV+9sZzPWiMgtsXoqTkY/8k7tEqn9TQo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5342fc6fb59d0595d26883c3cadff16ce58e44f3",
+        "rev": "f24c0439ea1296e295445e0d8117d282bdacaa9a",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1753429684,
-        "narHash": "sha256-9h7+4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ+SJjk=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7fd36ee82c0275fb545775cc5e4d30542899511d",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,12 +15,14 @@
           };
           screeps-launcher = pkgs.buildGoApplication {
             pname = "screeps-launcher";
-            version = "1.16.0";
+            version = 
+            if self ? shortRev 
+            then self.shortRev + pkgs.lib.optionalString self.dirty "-dirty"
+            else "dirty";
             src = ./.;
             modules = ./gomod2nix.toml;
             subPackages = [ "cmd/screeps-launcher" ];
-            # try 1.26, 1.23 was previously broken due to modules.txt not being generated
-            go = pkgs.go_1_26; 
+            go = pkgs.go;
           };
         in
         {

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,99 +1,134 @@
 schema = 3
 
 [mod]
-  [mod."github.com/c-bata/go-prompt"]
-    version = "v0.2.6"
-    hash = "sha256-C78Tk6uxPMyL2ftda8Z4Av801AaVKgVhEV/T2eRlFVY="
-  [mod."github.com/cavaliercoder/grab"]
-    version = "v2.0.0+incompatible"
-    hash = "sha256-MumGqHqp5bjWpMuULRdo9snsEMk5p4eRl50mmoFelyQ="
-  [mod."github.com/go-redis/redis/v7"]
-    version = "v7.4.1"
-    hash = "sha256-VI0cQedFW7abX5XgIHHLn13KvSxAvMQhcD14/4zYpMc="
-  [mod."github.com/go-resty/resty/v2"]
-    version = "v2.16.0"
-    hash = "sha256-IoXwZwYZ19tQQ8JJdd2C3+yz/H2plmydCAUpjUN/7m4="
-  [mod."github.com/golang/snappy"]
-    version = "v0.0.4"
-    hash = "sha256-Umx+5xHAQCN/Gi4HbtMhnDCSPFAXSsjVbXd8n5LhjAA="
-  [mod."github.com/google/go-github"]
-    version = "v17.0.0+incompatible"
-    hash = "sha256-5EGZnkefwLCEODLICIgaq39UoOzBJqpeLraoc2hJfM8="
-  [mod."github.com/google/go-querystring"]
-    version = "v1.1.0"
-    hash = "sha256-itsKgKghuX26czU79cK6C2n+lc27jm5Dw1XbIRgwZJY="
-  [mod."github.com/gorilla/mux"]
-    version = "v1.8.1"
-    hash = "sha256-nDABvAhlYgxUW2N/brrep7NkQXoSGcHhA+XI4+tK0F0="
-  [mod."github.com/gorilla/websocket"]
-    version = "v1.5.3"
-    hash = "sha256-vTIGEFMEi+30ZdO6ffMNJ/kId6pZs5bbyqov8xe9BM0="
-  [mod."github.com/hashicorp/go-version"]
-    version = "v1.7.0"
-    hash = "sha256-Umc/Q2mxRrPF4aEcDuDJq4lFBT+PSsnyANfyFwUIaxI="
-  [mod."github.com/klauspost/compress"]
-    version = "v1.17.11"
-    hash = "sha256-LFSIWy0C4VbiuPve0eKHr7Q7s4XtaGzsZ3qpO+6bEgc="
-  [mod."github.com/mattn/go-colorable"]
-    version = "v0.1.13"
-    hash = "sha256-qb3Qbo0CELGRIzvw7NVM1g/aayaz4Tguppk9MD2/OI8="
-  [mod."github.com/mattn/go-isatty"]
-    version = "v0.0.20"
-    hash = "sha256-qhw9hWtU5wnyFyuMbKx+7RB8ckQaFQ8D+8GKPkN3HHQ="
-  [mod."github.com/mattn/go-runewidth"]
-    version = "v0.0.16"
-    hash = "sha256-NC+ntvwIpqDNmXb7aixcg09il80ygq6JAnW0Gb5b/DQ="
-  [mod."github.com/mattn/go-tty"]
-    version = "v0.0.7"
-    hash = "sha256-5hufAOpijxHNw4Nd5fOuAqao7BWbTFinUlim1DN/zSY="
-  [mod."github.com/montanaflynn/stats"]
-    version = "v0.7.1"
-    hash = "sha256-0QXUA/syOtDSBooh3isAffrVAjpSoBmSMMuZfO5maHg="
-  [mod."github.com/otiai10/copy"]
-    version = "v1.14.0"
-    hash = "sha256-xsaL1ddkPS544y0Jv7u/INUALBYmYq29ddWvysLXk4A="
-  [mod."github.com/pkg/errors"]
-    version = "v0.9.1"
-    hash = "sha256-mNfQtcrQmu3sNg/7IwiieKWOgFQOVVe2yXgKBpe/wZw="
-  [mod."github.com/pkg/term"]
-    version = "v1.2.0-beta.2"
-    hash = "sha256-xb3tIQQk/0890fd9Q+1rtPE9+LoawUQS+m0v+iiB1Lk="
-  [mod."github.com/rivo/uniseg"]
-    version = "v0.4.7"
-    hash = "sha256-rDcdNYH6ZD8KouyyiZCUEy8JrjOQoAkxHBhugrfHjFo="
-  [mod."github.com/tcnksm/go-latest"]
-    version = "v0.0.0-20170313132115-e3007ae9052e"
-    hash = "sha256-pWvNEcL0PKbwsXJSH+BeeRnTrcXpyS0SeJZsjpE55Ag="
-  [mod."github.com/xdg-go/pbkdf2"]
-    version = "v1.0.0"
-    hash = "sha256-UKK8JrdxEeToqs53sUUMUZNQv8w+lzuhd7bNXryMN9o="
-  [mod."github.com/xdg-go/scram"]
-    version = "v1.1.2"
-    hash = "sha256-BPlloFojiFA8TiYIaBPW9BFBNkCmYD68JrY5gry1f64="
-  [mod."github.com/xdg-go/stringprep"]
-    version = "v1.0.4"
-    hash = "sha256-zGNSty2K8PoqMw71AHPvICuUvIzXzUvCW+fCNr3XmLE="
-  [mod."github.com/youmark/pkcs8"]
-    version = "v0.0.0-20240726163527-a2c0da244d78"
-    hash = "sha256-7ETUt8onE9mdUlvHT5xxzfh8mK0qw15ZSYXQCtah9p4="
-  [mod."go.mongodb.org/mongo-driver"]
-    version = "v1.17.1"
-    hash = "sha256-/0TG8G5SHfaRPnCH9L2Nc73JnhZZhb64TJ1pz1x2sHk="
-  [mod."golang.org/x/crypto"]
-    version = "v0.29.0"
-    hash = "sha256-sqckobR2VWucCgb7xpY2wLktnAA+XyXJbhCm80yCo78="
-  [mod."golang.org/x/net"]
-    version = "v0.31.0"
-    hash = "sha256-G+vGyCnn8jywmX3KvsIwhZkOv3+oAERNNeCeiQqfIL0="
-  [mod."golang.org/x/sync"]
-    version = "v0.9.0"
-    hash = "sha256-sGvzGqaaXE5dxohKkpbJMnu+bMmismsSqr8YMtrK+Rc="
-  [mod."golang.org/x/sys"]
-    version = "v0.27.0"
-    hash = "sha256-BXQcF9RrJ55Pq7Nl67TeFGkgkyuKkQ8hHKN4/L4ggWc="
-  [mod."golang.org/x/text"]
-    version = "v0.20.0"
-    hash = "sha256-YP8zSo2e9okqhxVB8me8sJyij2O0tTQEg5t+8bsIUx8="
-  [mod."gopkg.in/yaml.v2"]
-    version = "v2.4.0"
-    hash = "sha256-uVEGglIedjOIGZzHW4YwN1VoRSTK8o0eGZqzd+TNdd0="
+  [mod.'github.com/c-bata/go-prompt']
+    version = 'v0.2.6'
+    hash = 'sha256-C78Tk6uxPMyL2ftda8Z4Av801AaVKgVhEV/T2eRlFVY='
+
+  [mod.'github.com/cavaliercoder/grab']
+    version = 'v2.0.0+incompatible'
+    hash = 'sha256-MumGqHqp5bjWpMuULRdo9snsEMk5p4eRl50mmoFelyQ='
+
+  [mod.'github.com/go-redis/redis/v7']
+    version = 'v7.4.1'
+    hash = 'sha256-VI0cQedFW7abX5XgIHHLn13KvSxAvMQhcD14/4zYpMc='
+
+  [mod.'github.com/go-resty/resty/v2']
+    version = 'v2.17.2'
+    hash = 'sha256-9zXxBbRpgRwxRzbZZtOTqvOC38tSGpqeVFKzPVZyWBc='
+
+  [mod.'github.com/golang/snappy']
+    version = 'v0.0.4'
+    hash = 'sha256-Umx+5xHAQCN/Gi4HbtMhnDCSPFAXSsjVbXd8n5LhjAA='
+
+  [mod.'github.com/google/go-github']
+    version = 'v17.0.0+incompatible'
+    hash = 'sha256-5EGZnkefwLCEODLICIgaq39UoOzBJqpeLraoc2hJfM8='
+
+  [mod.'github.com/google/go-querystring']
+    version = 'v1.1.0'
+    hash = 'sha256-itsKgKghuX26czU79cK6C2n+lc27jm5Dw1XbIRgwZJY='
+
+  [mod.'github.com/gorilla/mux']
+    version = 'v1.8.1'
+    hash = 'sha256-nDABvAhlYgxUW2N/brrep7NkQXoSGcHhA+XI4+tK0F0='
+
+  [mod.'github.com/gorilla/websocket']
+    version = 'v1.5.3'
+    hash = 'sha256-vTIGEFMEi+30ZdO6ffMNJ/kId6pZs5bbyqov8xe9BM0='
+
+  [mod.'github.com/hashicorp/go-version']
+    version = 'v1.7.0'
+    hash = 'sha256-Umc/Q2mxRrPF4aEcDuDJq4lFBT+PSsnyANfyFwUIaxI='
+
+  [mod.'github.com/klauspost/compress']
+    version = 'v1.17.11'
+    hash = 'sha256-LFSIWy0C4VbiuPve0eKHr7Q7s4XtaGzsZ3qpO+6bEgc='
+
+  [mod.'github.com/mattn/go-colorable']
+    version = 'v0.1.13'
+    hash = 'sha256-qb3Qbo0CELGRIzvw7NVM1g/aayaz4Tguppk9MD2/OI8='
+
+  [mod.'github.com/mattn/go-isatty']
+    version = 'v0.0.20'
+    hash = 'sha256-qhw9hWtU5wnyFyuMbKx+7RB8ckQaFQ8D+8GKPkN3HHQ='
+
+  [mod.'github.com/mattn/go-runewidth']
+    version = 'v0.0.16'
+    hash = 'sha256-NC+ntvwIpqDNmXb7aixcg09il80ygq6JAnW0Gb5b/DQ='
+
+  [mod.'github.com/mattn/go-tty']
+    version = 'v0.0.7'
+    hash = 'sha256-5hufAOpijxHNw4Nd5fOuAqao7BWbTFinUlim1DN/zSY='
+
+  [mod.'github.com/montanaflynn/stats']
+    version = 'v0.7.1'
+    hash = 'sha256-0QXUA/syOtDSBooh3isAffrVAjpSoBmSMMuZfO5maHg='
+
+  [mod.'github.com/otiai10/copy']
+    version = 'v1.14.1'
+    hash = 'sha256-8RR7u17SbYg9AeBXVHIv5ZMU+kHmOcx0rLUKyz6YtU0='
+
+  [mod.'github.com/otiai10/mint']
+    version = 'v1.6.3'
+    hash = 'sha256-/FT3dYP2+UiW/qe1pxQ7HiS8et4+KHGPIMhc+8mHvzw='
+
+  [mod.'github.com/pkg/errors']
+    version = 'v0.9.1'
+    hash = 'sha256-mNfQtcrQmu3sNg/7IwiieKWOgFQOVVe2yXgKBpe/wZw='
+
+  [mod.'github.com/pkg/term']
+    version = 'v1.2.0-beta.2'
+    hash = 'sha256-xb3tIQQk/0890fd9Q+1rtPE9+LoawUQS+m0v+iiB1Lk='
+
+  [mod.'github.com/rivo/uniseg']
+    version = 'v0.4.7'
+    hash = 'sha256-rDcdNYH6ZD8KouyyiZCUEy8JrjOQoAkxHBhugrfHjFo='
+
+  [mod.'github.com/tcnksm/go-latest']
+    version = 'v0.0.0-20170313132115-e3007ae9052e'
+    hash = 'sha256-pWvNEcL0PKbwsXJSH+BeeRnTrcXpyS0SeJZsjpE55Ag='
+
+  [mod.'github.com/xdg-go/pbkdf2']
+    version = 'v1.0.0'
+    hash = 'sha256-UKK8JrdxEeToqs53sUUMUZNQv8w+lzuhd7bNXryMN9o='
+
+  [mod.'github.com/xdg-go/scram']
+    version = 'v1.1.2'
+    hash = 'sha256-BPlloFojiFA8TiYIaBPW9BFBNkCmYD68JrY5gry1f64='
+
+  [mod.'github.com/xdg-go/stringprep']
+    version = 'v1.0.4'
+    hash = 'sha256-zGNSty2K8PoqMw71AHPvICuUvIzXzUvCW+fCNr3XmLE='
+
+  [mod.'github.com/youmark/pkcs8']
+    version = 'v0.0.0-20240726163527-a2c0da244d78'
+    hash = 'sha256-7ETUt8onE9mdUlvHT5xxzfh8mK0qw15ZSYXQCtah9p4='
+
+  [mod.'go.mongodb.org/mongo-driver']
+    version = 'v1.17.9'
+    hash = 'sha256-k52Q0+ivK5kQUqufY02asWIX9fY/pygLO7P0nOeK/ko='
+
+  [mod.'golang.org/x/crypto']
+    version = 'v0.41.0'
+    hash = 'sha256-o5Di0lsFmYnXl7a5MBTqmN9vXMCRpE9ay71C1Ar8jEY='
+
+  [mod.'golang.org/x/net']
+    version = 'v0.43.0'
+    hash = 'sha256-bf3iQFrsC8BoarVaS0uSspEFAcr1zHp1uziTtBpwV34='
+
+  [mod.'golang.org/x/sync']
+    version = 'v0.16.0'
+    hash = 'sha256-sqKDRESeMzLe0jWGWltLZL/JIgrn0XaIeBWCzVN3Bks='
+
+  [mod.'golang.org/x/sys']
+    version = 'v0.35.0'
+    hash = 'sha256-ZKM8pesQE6NAFZeKQ84oPn5JMhGr8g4TSwLYAsHMGSI='
+
+  [mod.'golang.org/x/text']
+    version = 'v0.28.0'
+    hash = 'sha256-8UlJniGK+km4Hmrw6XMxELnExgrih7+z8tU26Cntmto='
+
+  [mod.'gopkg.in/yaml.v2']
+    version = 'v2.4.0'
+    hash = 'sha256-uVEGglIedjOIGZzHW4YwN1VoRSTK8o0eGZqzd+TNdd0='


### PR DESCRIPTION
## Summary

### Flake Changes
- Use `self.shortRev` for dynamic version (`a1b2c3d` or `a1b2c3d-dirty`)
- Use `pkgs.go` (latest) instead of pinned `go_1_26` - safe because `go.mod` controls compile-time compatibility
- Updated `flake.lock` and `gomod2nix.toml`

### CI Changes
- `renovate.json`: Added `pinDigests: true` to auto-pin GitHub Actions to digests; added rule to auto-merge digest updates
- `gomod2nix.yaml`: New workflow to auto-regenerate gomod2nix when go.mod changes (creates PR with automerge)