### PR TITLE
Fix yarn upgrade command for Yarn Classic

### DIFF
--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -59,7 +59,7 @@ func (l *Launcher) Upgrade() error {
 	if err != nil {
 		return err
 	}
-	return runYarn("up", "*")
+	return runYarn("upgrade", "--latest")
 }
 
 // Apply applies config without starting


### PR DESCRIPTION
`yarn up` is a Yarn Berry subcommand and fails on Yarn 1.x, which the launcher pins via `yarn set version 1.22.21`. Replace `yarn up *` with the Classic equivalent `yarn upgrade --latest` so the `upgrade` subcommand actually bumps dependencies to latest.

fixes #230 